### PR TITLE
fix 'unary operator expected'

### DIFF
--- a/processor/runner
+++ b/processor/runner
@@ -21,7 +21,7 @@ if [ $LOCKED -eq 0 ]; then
     echo "[$JOB] Running @ $START"
     . /app/runners/$RUNNER
 
-    if [ $EXIT_CODE != 0 ] && [ $ALERTER ] ; then
+    if [ "$EXIT_CODE" != 0 ] && [ $ALERTER ] ; then
       . /app/alerters/$ALERTER
     fi
 fi


### PR DESCRIPTION
I get the above error message from the logs after starting
'docker-compose up'.

Without this patch the code in the if condition is never run. See
example below:

  $ [ $EXIT_CODE != 0 ] && echo foo
  bash: [: !=: unary operator expected

  $ [ "$EXIT_CODE" != 0 ] && echo foo
  foo
