### PR TITLE
Fixing some commands

### DIFF
--- a/files/verify_kubectl
+++ b/files/verify_kubectl
@@ -3,7 +3,12 @@ export KUBERNETES_MASTER
 
 set -e
 
-MASTER_VERSION=$(curl -s $KUBERNETES_MASTER/version |  grep -i gitVersion | grep -o v[0-9]*\\.[0-9]*.\\.[0-9]*)
+if [[ "$KUBERNETES_MASTER" == *"https"* || "$KUBERNETES_MASTER" == *"443"* ]]; then
+  KUBE_TOKEN=$(</var/run/secrets/kubernetes.io/serviceaccount/token)
+  MASTER_VERSION=$(curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" $KUBERNETES_MASTER/version |  grep -i gitVersion | grep -o v[0-9]*\\.[0-9]*.\\.[0-9]*)
+else
+  MASTER_VERSION=$(curl -s $KUBERNETES_MASTER/version |  grep -i gitVersion | grep -o v[0-9]*\\.[0-9]*.\\.[0-9]*)
+fi
 LOCAL_VERSION=$(kubectl version --client | grep -i gitVersion | grep -o v[0-9]*\\.[0-9]*.\\.[0-9]*)
 
 test "$MASTER_VERSION" == "$LOCAL_VERSION" || ( echo "Client/Server K8S mismatch. Downloading $MASTER_VERSION" &&

--- a/reapers/kubernetes
+++ b/reapers/kubernetes
@@ -42,7 +42,7 @@ fi
 for job_name in "${all_jobs[@]}"
 do
   #Get the original job name
-  JOB=$(kubectl get jobs $job_name -o=jsonpath={.metadata.labels.service} 2> /dev/null)
+  JOB=$(kubectl get jobs $job_name -o=jsonpath={.metadata.labels.job-name} 2> /dev/null)
   if [ -f "/etc/default/$JOB" ] ; then
     pod=$(oldest_pod)
     STATUS=$(kubectl get pod $pod -o=jsonpath={.status.phase} 2> /dev/null); STATUS_CMD=$?

--- a/reapers/kubernetes
+++ b/reapers/kubernetes
@@ -42,7 +42,7 @@ fi
 for job_name in "${all_jobs[@]}"
 do
   #Get the original job name
-  JOB=$(kubectl get jobs $job_name -o=jsonpath={.metadata.labels.job-name} 2> /dev/null)
+  JOB=$(kubectl get jobs $job_name -o=jsonpath={.metadata.labels.service} 2> /dev/null)
   if [ -f "/etc/default/$JOB" ] ; then
     pod=$(oldest_pod)
     STATUS=$(kubectl get pod $pod -o=jsonpath={.status.phase} 2> /dev/null); STATUS_CMD=$?


### PR DESCRIPTION
A couple minor fixes:
- Fixed kubernetes reaper's `jsonpath`, in `1.2.0` the job name key is `job-name`: `{.metadata.labels.service} =>  {.metadata.labels.job-name}`
- Fixed `verify_kubectl` script so it uses K8s ServiceAccount token when `KUBERNETES_MASTER` is using SSL via token in: `/var/run/secrets/kubernetes.io/serviceaccount/token`
